### PR TITLE
Applied dependency updates by precog-sbt-precog

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -1,4 +1,4 @@
 {
-  "precog-quasar": "168.0.2",
-  "precog-async-blobstore": "2.1.5"
+  "precog-quasar": "168.0.7",
+  "precog-async-blobstore": "2.1.7"
 }


### PR DESCRIPTION
This PR brought to you by sbt-trickle via precog-sbt-precog. Changes:

Updated revision precog-async-blobstore 2.1.5 -> 2.1.7
Updated revision precog-quasar 168.0.2 -> 168.0.7