### PR TITLE
Lower default string type size

### DIFF
--- a/core/src/main/scala/quasar/destination/avalanche/AvalancheDestination.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/AvalancheDestination.scala
@@ -144,7 +144,7 @@ abstract class AvalancheDestination[F[_]: MonadResourceErr: Sync: Timer](
 
   private def withCharLength(mkType: Int => Type): Either[Type, Constructor[Type]] =
     Right(Constructor.Unary(
-      Labeled("size", Formal.integer(Some(Ior.both(1, 16000)), Some(stepOne))),
+      Labeled("size", Formal.integer(Some(Ior.both(1, 8000)), Some(stepOne))),
       mkType))
 
   private def withSeconds(mkType: Int => Type): Either[Type, Constructor[Type]] =


### PR DESCRIPTION
Actian has a pretty low row size limit and so if you pick a few strings it complains. Users can expand the size of strings if needed.