### PR TITLE
Reduce default size

### DIFF
--- a/core/src/main/scala/quasar/destination/avalanche/AvalancheDestination.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/AvalancheDestination.scala
@@ -145,7 +145,7 @@ abstract class AvalancheDestination[F[_]: MonadResourceErr: Sync: Timer](
 
   private def withCharLength(mkType: Int => Type): Either[Type, Constructor[Type]] =
     Right(Constructor.Unary(
-      Labeled("size", Formal.integer(Some(Ior.both(1, 16000)), Some(stepOne), Some(4000))),
+      Labeled("size", Formal.integer(Some(Ior.both(1, 16000)), Some(stepOne), Some(1024))),
       mkType))
 
   private def withSeconds(mkType: Int => Type): Either[Type, Constructor[Type]] =


### PR DESCRIPTION
The error for column too small is clearer and easier to resolve than the error for row is too large.