### PR TITLE
Google/Salesforce SSO support

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -1,5 +1,5 @@
 {
-  "precog-quasar": "208.0.0",
+  "precog-quasar": "208.0.0-99f5124",
   "precog-async-blobstore": "6.0.0",
-  "precog-quasar-lib-jdbc": "0.38.0"
+  "precog-quasar-lib-jdbc": "0.38.0-3927aec"
 }

--- a/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureConfig.scala
+++ b/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureConfig.scala
@@ -42,7 +42,7 @@ final case class AvalancheAzureConfig(
     accountName: AccountName,
     containerName: ContainerName,
     connectionUri: URI,
-    username: Option[Username],
+    username: Username,
     password: Option[ClusterPassword],
     googleAuth: Option[GoogleAuth],
     salesforceAuth: Option[SalesforceAuth],
@@ -89,10 +89,10 @@ object AvalancheAzureConfig {
         ("accountName" := c.accountName.value) ->:
         ("containerName" := c.containerName.value) ->:
         ("connectionUri" := c.connectionUri) ->:
-        ("username" :=? c.username) ->?:
+        ("username" := c.username) ->:
         ("clusterPassword" :=? c.password) ->?:
-        ("googleAuth" :=? c.password) ->?:
-        ("salesforceAuth" :=? c.password) ->?:
+        ("googleAuthId" :=? c.googleAuth) ->?:
+        ("salesforceAuthId" :=? c.salesforceAuth) ->?:
         ("writeMode" := c.writeMode) ->:
         ("credentials" := c.azureCredentials) ->:
         jEmptyObject,
@@ -101,10 +101,10 @@ object AvalancheAzureConfig {
          accountName <- (c --\ "accountName").as[String]
          containerName <- (c --\ "containerName").as[String]
          connectionUri <- (c --\ "connectionUri").as[URI]
-         username <- (c --\ "username").as[Option[Username]]
+         username <- (c --\ "username").as[Username]
          clusterPassword <- (c --\ "clusterPassword").as[Option[ClusterPassword]]
-         googleAuth <- (c --\ "googleAuth").as[Option[GoogleAuth]]
-         salesforceAuth <- (c --\ "salesforceAuth").as[Option[SalesforceAuth]]
+         googleAuth <- (c --\ "googleAuthId").as[Option[GoogleAuth]]
+         salesforceAuth <- (c --\ "salesforceAuthId").as[Option[SalesforceAuth]]
          writeMode <- (c --\ "writeMode").as[Option[WriteMode]]
          credentials <- (c --\ "credentials").as[AzureCredentials.ActiveDirectory]
        } yield AvalancheAzureConfig(

--- a/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureConfig.scala
+++ b/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureConfig.scala
@@ -42,8 +42,10 @@ final case class AvalancheAzureConfig(
     accountName: AccountName,
     containerName: ContainerName,
     connectionUri: URI,
-    username: Username,
-    password: ClusterPassword,
+    username: Option[Username],
+    password: Option[ClusterPassword],
+    googleAuth: Option[GoogleAuth],
+    salesforceAuth: Option[SalesforceAuth],
     writeMode: WriteMode,
     azureCredentials: AzureCredentials.ActiveDirectory) {
 
@@ -55,7 +57,9 @@ final case class AvalancheAzureConfig(
           TenantId(Redacted),
           ClientSecret(Redacted)),
       password =
-        ClusterPassword(Redacted))
+        password.as(ClusterPassword(Redacted)),
+      googleAuth = googleAuth.map(_.sanitized),
+      salesforceAuth = salesforceAuth.map(_.sanitized))
 }
 
 object AvalancheAzureConfig {
@@ -85,8 +89,10 @@ object AvalancheAzureConfig {
         ("accountName" := c.accountName.value) ->:
         ("containerName" := c.containerName.value) ->:
         ("connectionUri" := c.connectionUri) ->:
-        ("username" := c.username) ->:
-        ("clusterPassword" := c.password) ->:
+        ("username" :=? c.username) ->?:
+        ("clusterPassword" :=? c.password) ->?:
+        ("googleAuth" :=? c.password) ->?:
+        ("salesforceAuth" :=? c.password) ->?:
         ("writeMode" := c.writeMode) ->:
         ("credentials" := c.azureCredentials) ->:
         jEmptyObject,
@@ -95,8 +101,10 @@ object AvalancheAzureConfig {
          accountName <- (c --\ "accountName").as[String]
          containerName <- (c --\ "containerName").as[String]
          connectionUri <- (c --\ "connectionUri").as[URI]
-         username <- (c --\ "username").as[Username]
-         clusterPassword <- (c --\ "clusterPassword").as[ClusterPassword]
+         username <- (c --\ "username").as[Option[Username]]
+         clusterPassword <- (c --\ "clusterPassword").as[Option[ClusterPassword]]
+         googleAuth <- (c --\ "googleAuth").as[Option[GoogleAuth]]
+         salesforceAuth <- (c --\ "salesforceAuth").as[Option[SalesforceAuth]]
          writeMode <- (c --\ "writeMode").as[Option[WriteMode]]
          credentials <- (c --\ "credentials").as[AzureCredentials.ActiveDirectory]
        } yield AvalancheAzureConfig(
@@ -105,6 +113,8 @@ object AvalancheAzureConfig {
          connectionUri,
          username,
          clusterPassword,
+         googleAuth,
+         salesforceAuth,
          writeMode.getOrElse(WriteMode.Replace),
          credentials)))
 }

--- a/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureDestinationModule.scala
+++ b/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureDestinationModule.scala
@@ -50,8 +50,7 @@ object AvalancheAzureDestinationModule extends AvalancheDestinationModule[Avalan
       config.username,
       config.password,
       config.googleAuth,
-      config.salesforceAuth
-    )
+      config.salesforceAuth)
 
   def sanitizeDestinationConfig(config: Json): Json =
     config.as[AvalancheAzureConfig].fold(

--- a/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureDestinationModule.scala
+++ b/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureDestinationModule.scala
@@ -48,11 +48,14 @@ object AvalancheAzureDestinationModule extends AvalancheDestinationModule[Avalan
   val destinationType: DestinationType =
     DestinationType("avalanche-azure", 1L)
 
-  def transactorConfig(config: AvalancheAzureConfig): Either[NonEmptyList[String], TransactorConfig] =
-    Right(AvalancheTransactorConfig(
+  def connectionConfig(config: AvalancheAzureConfig): ConnectionConfig = 
+    ConnectionConfig(
       config.connectionUri,
       config.username,
-      config.password))
+      config.password,
+      config.googleAuth,
+      config.salesforceAuth
+    )
 
   def sanitizeDestinationConfig(config: Json): Json =
     config.as[AvalancheAzureConfig].fold(

--- a/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureDestinationModule.scala
+++ b/azure/src/main/scala/quasar/destination/avalanche/azure/AvalancheAzureDestinationModule.scala
@@ -18,13 +18,10 @@ package quasar.destination.avalanche.azure
 
 import quasar.destination.avalanche._
 
-import scala.util.{Either, Right}
-
-import java.lang.String
+import scala.util.Either
 
 import argonaut._, Argonaut._
 
-import cats.data.NonEmptyList
 import cats.effect.{
   ConcurrentEffect,
   ContextShift,
@@ -41,15 +38,14 @@ import quasar.api.destination.DestinationType
 import quasar.blobstore.azure.Azure
 import quasar.connector.MonadResourceErr
 import quasar.connector.destination.{Destination, PushmiPullyu}
-import quasar.lib.jdbc.TransactorConfig
 
 object AvalancheAzureDestinationModule extends AvalancheDestinationModule[AvalancheAzureConfig] {
 
   val destinationType: DestinationType =
     DestinationType("avalanche-azure", 1L)
 
-  def connectionConfig(config: AvalancheAzureConfig): ConnectionConfig = 
-    ConnectionConfig(
+  def connectionConfig(config: AvalancheAzureConfig): AvalancheTransactorConfig = 
+    AvalancheTransactorConfig(
       config.connectionUri,
       config.username,
       config.password,

--- a/azure/src/test/scala/quasar/destination/avalanche/azure/AvalancheAzureConfigSpec.scala
+++ b/azure/src/test/scala/quasar/destination/avalanche/azure/AvalancheAzureConfigSpec.scala
@@ -26,6 +26,8 @@ import org.specs2.mutable.Specification
 
 import quasar.blobstore.azure.{ AccountName, AzureCredentials, ClientId, ClientSecret, ContainerName, TenantId }
 
+import scala.{Some, None}
+
 object AvalancheAzureConfigSpec extends Specification {
   import WriteMode._
 
@@ -47,7 +49,9 @@ object AvalancheAzureConfigSpec extends Specification {
         ContainerName("bar"),
         new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
         Username("my user"),
-        ClusterPassword("super secret"),
+        Some(ClusterPassword("super secret")),
+        None,
+        None,
         Replace,
         AzureCredentials.ActiveDirectory(
           ClientId("client-id-uuid"),
@@ -57,6 +61,7 @@ object AvalancheAzureConfigSpec extends Specification {
     initialJson.as[AvalancheAzureConfig].result must beRight(cfg)
 
     cfg.asJson.as[AvalancheAzureConfig].result must beRight(cfg)
+
   }
 
   "avalanche-azure parses and prints a valid legacy config without username" >> {
@@ -77,7 +82,9 @@ object AvalancheAzureConfigSpec extends Specification {
         ContainerName("bar"),
         new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
         Username("dbuser"),
-        ClusterPassword("super secret"),
+        Some(ClusterPassword("super secret")),
+        None,
+        None,
         Truncate,
         AzureCredentials.ActiveDirectory(
           ClientId("client-id-uuid"),
@@ -108,7 +115,41 @@ object AvalancheAzureConfigSpec extends Specification {
         ContainerName("bar"),
         new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
         Username("my user"),
-        ClusterPassword("super secret"),
+        Some(ClusterPassword("super secret")),
+        None,
+        None,
+        Truncate,
+        AzureCredentials.ActiveDirectory(
+          ClientId("client-id-uuid"),
+          TenantId("tenant-id-uuid"),
+          ClientSecret("client-secret-string")))
+
+    initialJson.as[AvalancheAzureConfig].result must beRight(cfg)
+
+    cfg.asJson.as[AvalancheAzureConfig].result must beRight(cfg)
+  } 
+
+  "avalanche-azure parses and prints a valid config with google auth and no other auth" >> {
+    val initialJson = Json.obj(
+      "accountName" := "foo",
+      "containerName" := "bar",
+      "connectionUri" := "jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;",
+      "googleAuthId" := "00000000-0000-0000-0000-000000000000",
+      "writeMode" := "truncate",
+      "credentials" := Json.obj(
+        "clientId" := "client-id-uuid",
+        "tenantId" := "tenant-id-uuid",
+        "clientSecret" := "client-secret-string"))
+
+    val cfg =
+      AvalancheAzureConfig(
+        AccountName("foo"),
+        ContainerName("bar"),
+        new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
+        Username("dbuser"),
+        None,
+        Some(GoogleAuth(UUID0)),
+        None,
         Truncate,
         AzureCredentials.ActiveDirectory(
           ClientId("client-id-uuid"),
@@ -119,4 +160,37 @@ object AvalancheAzureConfigSpec extends Specification {
 
     cfg.asJson.as[AvalancheAzureConfig].result must beRight(cfg)
   }
+
+  "avalanche-azure parses and prints a valid config with salesforce auth and no other auth" >> {
+    val initialJson = Json.obj(
+      "accountName" := "foo",
+      "containerName" := "bar",
+      "connectionUri" := "jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;",
+      "salesforceAuthId" := "00000000-0000-0000-0000-000000000000",
+      "writeMode" := "truncate",
+      "credentials" := Json.obj(
+        "clientId" := "client-id-uuid",
+        "tenantId" := "tenant-id-uuid",
+        "clientSecret" := "client-secret-string"))
+
+    val cfg =
+      AvalancheAzureConfig(
+        AccountName("foo"),
+        ContainerName("bar"),
+        new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
+        Username("dbuser"),
+        None,
+        None,
+        Some(SalesforceAuth(UUID0)),
+        Truncate,
+        AzureCredentials.ActiveDirectory(
+          ClientId("client-id-uuid"),
+          TenantId("tenant-id-uuid"),
+          ClientSecret("client-secret-string")))
+
+    initialJson.as[AvalancheAzureConfig].result must beRight(cfg)
+
+    cfg.asJson.as[AvalancheAzureConfig].result must beRight(cfg)
+  }
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -48,10 +48,12 @@ lazy val core = project
       "com.precog" %% "async-blobstore-core" % asyncBlobstoreVersion.value,
       "com.precog" %% "quasar-lib-jdbc" % quasarPluginJdbcVersion.value,
       "com.precog" %% "quasar-api" % quasarVersion.value,
-      "org.http4s" %% "http4s-argonaut" % http4sVersion,
-      "org.http4s" %% "http4s-ember-client" % http4sVersion,
       "io.chrisdavenport" %% "log4cats-slf4j" % "1.0.1",
       "org.specs2" %% "specs2-core" % specs2Version % Test),
+    quasarPluginDependencies ++= Seq(
+      "org.http4s" %% "http4s-argonaut" % http4sVersion,
+      "org.http4s" %% "http4s-ember-client" % http4sVersion,
+    ),
     assemblyExcludedJars in assembly := {
       val cp = (fullClasspath in assembly).value
       cp.filter(_.data.getName != "iijdbc.jar") // exclude everything but iijdbc.jar

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val quasarPluginJdbcVersion =
   Def.setting[String](managedVersions.value("precog-quasar-lib-jdbc"))
 
 lazy val specs2Version = "4.9.4"
+lazy val http4sVersion = "0.21.24"
 
 lazy val buildSettings = Seq(
   logBuffered in Test := githubIsWorkflowBuild.value)
@@ -47,13 +48,17 @@ lazy val core = project
       "com.precog" %% "async-blobstore-core" % asyncBlobstoreVersion.value,
       "com.precog" %% "quasar-lib-jdbc" % quasarPluginJdbcVersion.value,
       "com.precog" %% "quasar-api" % quasarVersion.value,
+      "org.http4s" %% "http4s-argonaut" % http4sVersion,
+      "org.http4s" %% "http4s-ember-client" % http4sVersion,
       "io.chrisdavenport" %% "log4cats-slf4j" % "1.0.1",
       "org.specs2" %% "specs2-core" % specs2Version % Test),
     assemblyExcludedJars in assembly := {
       val cp = (fullClasspath in assembly).value
       cp.filter(_.data.getName != "iijdbc.jar") // exclude everything but iijdbc.jar
     },
-    packageBin in Compile := (assembly in Compile).value)
+    packageBin in Compile := (assembly in Compile).value,
+    addCompilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
+    scalacOptions += "-P:silencer:globalFilters=http4s-argonaut")
   .evictToLocal("QUASAR_PATH", "api", true)
   .evictToLocal("QUASAR_PATH", "connector", true)
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,11 +49,9 @@ lazy val core = project
       "com.precog" %% "quasar-lib-jdbc" % quasarPluginJdbcVersion.value,
       "com.precog" %% "quasar-api" % quasarVersion.value,
       "io.chrisdavenport" %% "log4cats-slf4j" % "1.0.1",
-      "org.specs2" %% "specs2-core" % specs2Version % Test),
-    quasarPluginDependencies ++= Seq(
       "org.http4s" %% "http4s-argonaut" % http4sVersion,
       "org.http4s" %% "http4s-ember-client" % http4sVersion,
-    ),
+      "org.specs2" %% "specs2-core" % specs2Version % Test),
     assemblyExcludedJars in assembly := {
       val cp = (fullClasspath in assembly).value
       cp.filter(_.data.getName != "iijdbc.jar") // exclude everything but iijdbc.jar

--- a/core/src/main/scala/quasar/destination/avalanche/AvalancheDestinationModule.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/AvalancheDestinationModule.scala
@@ -32,7 +32,7 @@ import doobie._
 import org.slf4s.{Logger, LoggerFactory}
 
 import quasar.api.destination.{DestinationError => DE}
-import quasar.connector.MonadResourceErr
+import quasar.connector.{GetAuth, MonadResourceErr}
 import quasar.connector.destination._
 import quasar.lib.jdbc.{ManagedTransactor, Redacted, TransactorConfig}
 
@@ -53,7 +53,8 @@ abstract class AvalancheDestinationModule[C: DecodeJson] extends DestinationModu
 
   def destination[F[_]: ConcurrentEffect: ContextShift: MonadResourceErr: Timer](
       config: Json,
-      pushPull: PushmiPullyu[F])
+      pushPull: PushmiPullyu[F],
+      auth: GetAuth[F])
       : Resource[F, Either[InitError, Destination[F]]] = {
 
     val id = s"${destinationType.name.value}-v${destinationType.version}"

--- a/core/src/main/scala/quasar/destination/avalanche/AvalancheDestinationModule.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/AvalancheDestinationModule.scala
@@ -79,13 +79,10 @@ abstract class AvalancheDestinationModule[C: DecodeJson] extends DestinationModu
 
       xaCfg <- EitherT(
         Resource.eval(
-          connectionConfig(cfg).transactorConfig( 
-            auth
-          ).map(_.leftMap(s => 
-             DE.InvalidConfiguration(destinationType, sanitizedJson, scalaz.NonEmptyList(s))
-           ))
-        )
-      )
+          connectionConfig(cfg)
+            .transactorConfig(auth)
+            .map(_.leftMap(s => 
+             DE.InvalidConfiguration(destinationType, sanitizedJson, scalaz.NonEmptyList(s))))))
 
       tag <- liftF(Sync[F].delay(Random.alphanumeric.take(6).mkString))
 

--- a/core/src/main/scala/quasar/destination/avalanche/AvalancheDestinationModule.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/AvalancheDestinationModule.scala
@@ -141,7 +141,7 @@ abstract class AvalancheDestinationModule[C: DecodeJson] extends DestinationModu
               raiseInvalidConfError
             ))
             email <- EitherT.fromOptionF(
-              UserInfoGetter.fromGoogle[F](token),
+              emailGetter(token),
               raiseInvalidConfError( 
                 "Querying user info using the token acquired via the auth key did not yield an email. Check the scopes granted to the token."
               )

--- a/core/src/main/scala/quasar/destination/avalanche/AvalancheTransactorConfig.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/AvalancheTransactorConfig.scala
@@ -39,21 +39,21 @@ case class AvalancheTransactorConfig(
   salesforceAuth: Option[SalesforceAuth]) {
 
   def transactorConfig[F[_]: ConcurrentEffect: Timer: ContextShift](
-    getAuth: GetAuth[F]): F[Either[String, TransactorConfig]] = {
+      getAuth: GetAuth[F])
+      : F[Either[String, TransactorConfig]] = {
 
     def getConfigForAuthKey(
-      authKey: UUID, 
-      emailGetter: Credentials.Token => F[Option[Email]]
-    ): F[Either[String, TransactorConfig]] = 
-        (
-          for {
-            token <- EitherT(UserInfoGetter.getToken[F](getAuth, authKey))
-            email <- EitherT.fromOptionF(
-              emailGetter(token),
-                "Querying user info using the token acquired via the auth key did not yield an email. Check the scopes granted to the token."
-            )
-          } yield AvalancheTransactorConfig.fromToken(connectionUri, Username(email.asString), token)
-        ).value
+        authKey: UUID, 
+        emailGetter: Credentials.Token => F[Option[Email]])
+        : F[Either[String, TransactorConfig]] = 
+      (
+        for {
+          token <- EitherT(UserInfoGetter.getToken[F](getAuth, authKey))
+          email <- EitherT.fromOptionF(
+            emailGetter(token),
+            "Querying user info using the token acquired via the auth key did not yield an email. Check the scopes granted to the token.")
+        } yield AvalancheTransactorConfig.fromToken(connectionUri, Username(email.asString), token)
+      ).value
 
     (password, googleAuth, salesforceAuth) match {
       case (Some(password), None, None) => 
@@ -66,7 +66,7 @@ case class AvalancheTransactorConfig(
         getConfigForAuthKey(authKey, UserInfoGetter.fromSalesforce[F](_))
 
       case _ => 
-          "Must specify exactly one of: 'username'+'clusterPassword', 'googleAuthId' or 'salesforceAuthId'".asLeft[TransactorConfig].pure[F]
+        "Must specify exactly one of: 'username'+'clusterPassword', 'googleAuthId' or 'salesforceAuthId'".asLeft[TransactorConfig].pure[F]
     }
   }
 }
@@ -104,19 +104,18 @@ object AvalancheTransactorConfig {
       username: Username,
       password: ClusterPassword)
       : TransactorConfig = 
-        fromDetails(connectionUrl, username, password.asString) 
+    fromDetails(connectionUrl, username, password.asString) 
 
   private val utf8 = Charset.forName("UTF-8")
 
   def fromToken(
-    connectionUrl: URI,
-    username: Username,
-    token: Credentials.Token
-  ): TransactorConfig = 
+      connectionUrl: URI,
+      username: Username,
+      token: Credentials.Token)
+      : TransactorConfig = 
     fromDetails(
       connectionUrl, 
       username, 
-      s"access_token=${new String(token.toByteArray, utf8)}"
-    )
+      s"access_token=${new String(token.toByteArray, utf8)}")
 
 }

--- a/core/src/main/scala/quasar/destination/avalanche/AvalancheTransactorConfig.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/AvalancheTransactorConfig.scala
@@ -43,7 +43,7 @@ case class AvalancheTransactorConfig(
 
     def getConfigForAuthKey(
       authKey: UUID, 
-      emailGetter: Credentials.Token => F[Option[String]]
+      emailGetter: Credentials.Token => F[Option[Email]]
     ): F[Either[String, TransactorConfig]] = 
         (
           for {
@@ -52,7 +52,7 @@ case class AvalancheTransactorConfig(
               emailGetter(token),
                 "Querying user info using the token acquired via the auth key did not yield an email. Check the scopes granted to the token."
             )
-          } yield AvalancheTransactorConfig.fromToken(connectionUri, Username(email), token)
+          } yield AvalancheTransactorConfig.fromToken(connectionUri, Username(email.asString), token)
         ).value
 
     (password, googleAuth, salesforceAuth) match {

--- a/core/src/main/scala/quasar/destination/avalanche/Email.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/Email.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.avalanche
+
+import java.lang.String
+
+import scala.AnyVal
+
+import argonaut._, Argonaut._
+
+final case class Email(asString: String) extends AnyVal
+
+object Email {
+  implicit val emailDecodeJson: DecodeJson[Email] =
+    jdecode1(Email(_))
+
+  implicit val emailEncodeJson: EncodeJson[Email] =
+    jencode1(_.asString)
+}

--- a/core/src/main/scala/quasar/destination/avalanche/GoogleAuth.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/GoogleAuth.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package quasar.destination.avalanche
 
 import java.util.UUID
@@ -8,6 +24,9 @@ final case class GoogleAuth(authId: UUID) {
 }
 
 object GoogleAuth {
-  implicit val codec: CodecJson[GoogleAuth] = 
-    casecodec1(GoogleAuth.apply, GoogleAuth.unapply)("authId")
+  implicit val googleAuthDecodeJson: DecodeJson[GoogleAuth] =
+    jdecode1(GoogleAuth(_))
+
+  implicit val googleAuthEncodeJson: EncodeJson[GoogleAuth] =
+    jencode1(_.authId)
 }

--- a/core/src/main/scala/quasar/destination/avalanche/GoogleAuth.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/GoogleAuth.scala
@@ -1,0 +1,13 @@
+package quasar.destination.avalanche
+
+import java.util.UUID
+import argonaut._, Argonaut._
+
+final case class GoogleAuth(authId: UUID) {
+  def sanitized: GoogleAuth = GoogleAuth(UUID0)
+}
+
+object GoogleAuth {
+  implicit val codec: CodecJson[GoogleAuth] = 
+    casecodec1(GoogleAuth.apply, GoogleAuth.unapply)("authId")
+}

--- a/core/src/main/scala/quasar/destination/avalanche/SalesforceAuth.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/SalesforceAuth.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package quasar.destination.avalanche
 
 import java.util.UUID
@@ -8,6 +24,9 @@ final case class SalesforceAuth(authId: UUID) {
 }
 
 object SalesforceAuth {
-  implicit val codec: CodecJson[SalesforceAuth] = 
-    casecodec1(SalesforceAuth.apply, SalesforceAuth.unapply)("authId")
+  implicit val salesforceAuthDecodeJson: DecodeJson[SalesforceAuth] =
+    jdecode1(SalesforceAuth(_))
+
+  implicit val salesforceAuthEncodeJson: EncodeJson[SalesforceAuth] =
+    jencode1(_.authId)
 }

--- a/core/src/main/scala/quasar/destination/avalanche/SalesforceAuth.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/SalesforceAuth.scala
@@ -1,0 +1,13 @@
+package quasar.destination.avalanche
+
+import java.util.UUID
+import argonaut._, Argonaut._
+
+final case class SalesforceAuth(authId: UUID) {
+  def sanitized: SalesforceAuth = SalesforceAuth(UUID0)
+}
+
+object SalesforceAuth {
+  implicit val codec: CodecJson[SalesforceAuth] = 
+    casecodec1(SalesforceAuth.apply, SalesforceAuth.unapply)("authId")
+}

--- a/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
@@ -31,14 +31,10 @@ import org.http4s.headers.Authorization
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.argonaut.jsonDecoder
 import org.http4s.syntax.literals._
-import org.http4s.client.middleware._
 
-import scala.concurrent.duration._
-import scala.Predef.???
 import scala.{Option, Some, None, StringContext, Either, Left, Right}
 
 import quasar.connector.{Credentials, GetAuth, ExternalCredentials}
-import cats.data.EitherT
 import quasar.api.destination.DestinationError
 
 object UserInfoGetter {
@@ -59,10 +55,14 @@ object UserInfoGetter {
     EmberClientBuilder
       .default[F]
       .build
-      .use(client => 
-          ResponseLogger(true, true, _ => false)(
-            RequestLogger(true, true, _ => false)(client)
-          ).expect[Json](req).map(v => (v -| "email").flatMap(_.as[String].toOption))
+      .use(
+        _.expect[Json](req)
+          .map(v => 
+            (v -| "email")
+              .flatMap(
+                _.as[String].toOption
+              )
+          )
       )
   }
 

--- a/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
@@ -16,7 +16,7 @@
 
 package quasar.destination.avalanche
 
-import argonaut._, Argonaut._
+import argonaut._
 
 import cats._
 import cats.effect._
@@ -40,7 +40,7 @@ object UserInfoGetter {
 
   private val utf8 = StandardCharsets.UTF_8
 
-  private def emailFromUserinfo[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token, userinfoUrl: Uri): F[Option[String]] = {
+  private def emailFromUserinfo[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token, userinfoUrl: Uri): F[Option[Email]] = {
     val req = Request[F](
       uri = userinfoUrl,
       method = Method.GET,
@@ -59,16 +59,16 @@ object UserInfoGetter {
           .map(v => 
             (v -| "email")
               .flatMap(
-                _.as[String].toOption
+                _.as[Email].toOption
               )
           )
       )
   }
 
-  def fromGoogle[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token): F[Option[String]] = 
+  def fromGoogle[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token): F[Option[Email]] = 
     emailFromUserinfo[F](token, uri"https://openidconnect.googleapis.com/v1/userinfo")
 
-  def fromSalesforce[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token): F[Option[String]] = 
+  def fromSalesforce[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token): F[Option[Email]] = 
     emailFromUserinfo[F](token, uri"https://login.salesforce.com/services/oauth2/userinfo")
 
   def getToken[F[_]: Monad: Clock](

--- a/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
@@ -31,6 +31,7 @@ import org.http4s.headers.Authorization
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.argonaut.jsonDecoder
 import org.http4s.syntax.literals._
+import org.http4s.client.middleware._
 
 import scala.concurrent.duration._
 import scala.Predef.???
@@ -62,7 +63,9 @@ object UserInfoGetter {
       .withTimeout(Duration.Inf)
       .build
       .use(client => 
-          client.expect[Json](req).map(v => (v -| "email").flatMap(_.as[String].toOption))
+          ResponseLogger(true, true, _ => false)(
+            RequestLogger(true, true, _ => false)(client)
+          ).expect[Json](req).map(v => (v -| "email").flatMap(_.as[String].toOption))
       )
   }
 

--- a/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.avalanche
+
+import argonaut._, Argonaut._
+
+import cats._
+import cats.effect._
+import cats.implicits._
+
+import java.lang.String
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+import org.http4s.{Request, Uri, Method, Headers, AuthScheme}
+import org.http4s.headers.Authorization
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.argonaut.jsonDecoder
+import org.http4s.syntax.literals._
+
+import scala.concurrent.duration._
+import scala.Predef.???
+import scala.{Option, Some, None, StringContext, Either, Left, Right}
+
+import quasar.connector.{Credentials, GetAuth, ExternalCredentials}
+import cats.data.EitherT
+import quasar.api.destination.DestinationError
+
+object UserInfoGetter {
+
+  private val utf8 = StandardCharsets.UTF_8
+
+  private def emailFromUserinfo[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token, userinfoUrl: Uri): F[Option[String]] = {
+    val req = Request[F](
+      uri = userinfoUrl,
+      method = Method.GET,
+      headers = Headers.of(
+        Authorization(
+          org.http4s.Credentials.Token(AuthScheme.Bearer, new String(token.toByteArray, utf8))
+        )
+      )
+    )
+
+    EmberClientBuilder
+      .default[F]
+      .withMaxTotal(400)
+      .withMaxPerKey(_ => 200)
+      .withTimeout(Duration.Inf)
+      .build
+      .use(client => 
+          client.expect[Json](req).map(v => (v -| "email").flatMap(_.as[String].toOption))
+      )
+  }
+
+  def fromGoogle[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token): F[Option[String]] = 
+    emailFromUserinfo[F](token, uri"https://openidconnect.googleapis.com/v1/userinfo")
+
+  def fromSalesforce[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token): F[Option[String]] = 
+    emailFromUserinfo[F](token, uri"https://login.salesforce.com/services/oauth2/userinfo")
+
+  type InitError = DestinationError.InitializationError[Json]
+
+  def getToken[F[_]: Monad: Clock](
+    getAuth: GetAuth[F], 
+    key: UUID, 
+    raiseInvalidConfError: String => InitError
+  ): F[Either[InitError, Credentials.Token]] = {
+
+    def verifyCreds(cred: Credentials): Either[InitError, Credentials.Token] = cred match {
+      case t: Credentials.Token => Right(t)
+      case _ => Left(raiseInvalidConfError("Unsupported auth type provided by the configured auth key"))
+    }
+
+    getAuth(key).flatMap {
+      case Some(ExternalCredentials.Perpetual(t)) => 
+        verifyCreds(t).pure[F]
+
+      case Some(ExternalCredentials.Temporary(acquire, renew)) => 
+        for {
+          creds <- acquire.flatMap(_.nonExpired)
+          result <- creds match {
+            case None => 
+              renew >> 
+                acquire
+                  .flatMap(_.nonExpired)
+                  .map(_.toRight(raiseInvalidConfError("Failed to acquire a non-expired token")))
+            case Some(t) => 
+              t.asRight[InitError].pure[F]
+          }
+        } yield result.flatMap(verifyCreds)
+
+      case None => 
+        raiseInvalidConfError("No auth found for the configured auth key")
+          .asLeft[Credentials.Token].pure[F]
+
+      case Some(_) => 
+        raiseInvalidConfError("Unsupported credential type provided by the configured auth key")
+          .asLeft[Credentials.Token].pure[F]
+    }
+
+  }
+}

--- a/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/UserInfoGetter.scala
@@ -35,7 +35,6 @@ import org.http4s.syntax.literals._
 import scala.{Option, Some, None, StringContext, Either, Left, Right}
 
 import quasar.connector.{Credentials, GetAuth, ExternalCredentials}
-import quasar.api.destination.DestinationError
 
 object UserInfoGetter {
 
@@ -72,12 +71,9 @@ object UserInfoGetter {
   def fromSalesforce[F[_]: ConcurrentEffect: Timer: ContextShift](token: Credentials.Token): F[Option[String]] = 
     emailFromUserinfo[F](token, uri"https://login.salesforce.com/services/oauth2/userinfo")
 
-  type InitError = DestinationError.InitializationError[Json]
-
   def getToken[F[_]: Monad: Clock](
     getAuth: GetAuth[F], 
     key: UUID
-    // raiseInvalidConfError: String => InitError
   ): F[Either[String, Credentials.Token]] = {
 
     def verifyCreds(cred: Credentials): Either[String, Credentials.Token] = cred match {

--- a/core/src/main/scala/quasar/destination/avalanche/package.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/package.scala
@@ -23,6 +23,7 @@ import scala.util.matching.Regex
 import java.lang.{String, System}
 import java.net.URI
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 
 import cats.data.NonEmptyList
 import cats.implicits._
@@ -35,6 +36,8 @@ import quasar.connector.render.RenderConfig
 
 package object avalanche {
   type TableName = String
+
+  private[destination] val UUID0: UUID = new UUID(0L, 0L)
 
   val GranteeDbadminGrp: Fragment = Fragment.const("group dbadmingrp")
 

--- a/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpConfig.scala
+++ b/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpConfig.scala
@@ -31,7 +31,7 @@ import quasar.lib.jdbc.Redacted
 
 final case class AvalancheHttpConfig(
     connectionUri: URI,
-    username: Option[Username],
+    username: Username,
     clusterPassword: Option[ClusterPassword],
     googleAuth: Option[GoogleAuth],
     salesforceAuth: Option[SalesforceAuth],
@@ -49,5 +49,5 @@ final case class AvalancheHttpConfig(
 object AvalancheHttpConfig {
   implicit val avalancheHttpConfigCodecJson: CodecJson[AvalancheHttpConfig] =
     casecodec7(AvalancheHttpConfig.apply, AvalancheHttpConfig.unapply)(
-      "connectionUri", "username", "clusterPassword", "googleAuth", "salesforceAuth", "writeMode", "baseUrl")
+      "connectionUri", "username", "clusterPassword", "googleAuthId", "salesforceAuthId", "writeMode", "baseUrl")
 }

--- a/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpConfig.scala
+++ b/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpConfig.scala
@@ -25,21 +25,29 @@ import java.net.URI
 
 import argonaut._, Argonaut._
 
+import cats.syntax.functor._
+
 import quasar.lib.jdbc.Redacted
 
 final case class AvalancheHttpConfig(
     connectionUri: URI,
-    username: Username,
-    clusterPassword: ClusterPassword,
+    username: Option[Username],
+    clusterPassword: Option[ClusterPassword],
+    googleAuth: Option[GoogleAuth],
+    salesforceAuth: Option[SalesforceAuth],
     writeMode: WriteMode,
     baseUrl: Option[URI]) {
 
   def sanitized: AvalancheHttpConfig =
-    copy(clusterPassword = ClusterPassword(Redacted))
+    copy(
+      clusterPassword =
+        clusterPassword.as(ClusterPassword(Redacted)),
+      googleAuth = googleAuth.map(_.sanitized),
+      salesforceAuth = salesforceAuth.map(_.sanitized))
 }
 
 object AvalancheHttpConfig {
   implicit val avalancheHttpConfigCodecJson: CodecJson[AvalancheHttpConfig] =
-    casecodec5(AvalancheHttpConfig.apply, AvalancheHttpConfig.unapply)(
-      "connectionUri", "username", "clusterPassword", "writeMode", "baseUrl")
+    casecodec7(AvalancheHttpConfig.apply, AvalancheHttpConfig.unapply)(
+      "connectionUri", "username", "clusterPassword", "googleAuth", "salesforceAuth", "writeMode", "baseUrl")
 }

--- a/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpDestinationModule.scala
+++ b/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpDestinationModule.scala
@@ -44,8 +44,7 @@ object AvalancheHttpDestinationModule extends AvalancheDestinationModule[Avalanc
       config.username,
       config.clusterPassword,
       config.googleAuth,
-      config.salesforceAuth
-    )
+      config.salesforceAuth)
 
   def sanitizeDestinationConfig(config: Json): Json =
     config.as[AvalancheHttpConfig].fold(

--- a/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpDestinationModule.scala
+++ b/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpDestinationModule.scala
@@ -18,11 +18,10 @@ package quasar.destination.avalanche.http
 
 import quasar.destination.avalanche._
 
-import scala._, Predef._
+import scala._
 
 import argonaut._, Argonaut._
 
-import cats.data.NonEmptyList
 import cats.effect._
 import cats.implicits._
 
@@ -33,15 +32,14 @@ import org.slf4s.Logger
 import quasar.api.destination.DestinationType
 import quasar.connector.MonadResourceErr
 import quasar.connector.destination.{Destination, PushmiPullyu}
-import quasar.lib.jdbc.TransactorConfig
 
 object AvalancheHttpDestinationModule extends AvalancheDestinationModule[AvalancheHttpConfig] {
 
   val destinationType: DestinationType =
     DestinationType("avalanche-http", 1L)
 
-  def connectionConfig(config: AvalancheHttpConfig): ConnectionConfig = 
-    ConnectionConfig(
+  def connectionConfig(config: AvalancheHttpConfig): AvalancheTransactorConfig = 
+    AvalancheTransactorConfig(
       config.connectionUri,
       config.username,
       config.clusterPassword,

--- a/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpDestinationModule.scala
+++ b/http/src/main/scala/quasar/destination/avalanche/http/AvalancheHttpDestinationModule.scala
@@ -40,11 +40,14 @@ object AvalancheHttpDestinationModule extends AvalancheDestinationModule[Avalanc
   val destinationType: DestinationType =
     DestinationType("avalanche-http", 1L)
 
-  def transactorConfig(config: AvalancheHttpConfig): Either[NonEmptyList[String], TransactorConfig] =
-    Right(AvalancheTransactorConfig(
+  def connectionConfig(config: AvalancheHttpConfig): ConnectionConfig = 
+    ConnectionConfig(
       config.connectionUri,
       config.username,
-      config.clusterPassword))
+      config.clusterPassword,
+      config.googleAuth,
+      config.salesforceAuth
+    )
 
   def sanitizeDestinationConfig(config: Json): Json =
     config.as[AvalancheHttpConfig].fold(

--- a/http/src/test/scala/quasar/destination/avalanche/http/AvalancheHttpConfigSpec.scala
+++ b/http/src/test/scala/quasar/destination/avalanche/http/AvalancheHttpConfigSpec.scala
@@ -41,7 +41,9 @@ object AvalancheHttpConfigSpec extends Specification {
       AvalancheHttpConfig(
         URI.create("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
         Username("myuser"),
-        ClusterPassword("super secret"),
+        Some(ClusterPassword("super secret")),
+        None,
+        None,
         Truncate,
         Some(URI.create("http://example.com/precog")))
 
@@ -61,7 +63,9 @@ object AvalancheHttpConfigSpec extends Specification {
       AvalancheHttpConfig(
         URI.create("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
         Username("myuser"),
-        ClusterPassword("super secret"),
+        Some(ClusterPassword("super secret")),
+        None,
+        None,
         Create,
         None)
 
@@ -69,4 +73,68 @@ object AvalancheHttpConfigSpec extends Specification {
 
     cfg.asJson.as[AvalancheHttpConfig].result must beRight(cfg)
   }
+
+  "avalanche-http valid salesforceAuthId is parsed" >> {
+    val json = Json(
+      "connectionUri" := "jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;",
+      "salesforceAuthId" := "00000000-0000-0000-0000-000000000000",
+      "writeMode" := "create")
+
+    val cfg =
+      AvalancheHttpConfig(
+        URI.create("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
+        Username.DbUser,
+        None,
+        None,
+        Some(SalesforceAuth(UUID0)),
+        Create,
+        None)
+
+    json.as[AvalancheHttpConfig].result must beRight(cfg)
+
+    cfg.asJson.as[AvalancheHttpConfig].result must beRight(cfg)
+  }
+
+  "avalanche-http valid googleAuth is parsed" >> {
+    val json = Json(
+      "connectionUri" := "jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;",
+      "googleAuthId" := "00000000-0000-0000-0000-000000000000",
+      "writeMode" := "create")
+
+    val cfg =
+      AvalancheHttpConfig(
+        URI.create("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
+        Username.DbUser,
+        None,
+        Some(GoogleAuth(UUID0)),
+        None,
+        Create,
+        None)
+
+    json.as[AvalancheHttpConfig].result must beRight(cfg)
+
+    cfg.asJson.as[AvalancheHttpConfig].result must beRight(cfg)
+  }
+
+  "avalanche-http clusterPassword is optional" >> {
+    val json = Json(
+      "connectionUri" := "jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;",
+      "username" := "myuser",
+      "writeMode" := "create")
+
+    val cfg =
+      AvalancheHttpConfig(
+        URI.create("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
+        Username("myuser"),
+        None,
+        None,
+        None,
+        Create,
+        None)
+
+    json.as[AvalancheHttpConfig].result must beRight(cfg)
+
+    cfg.asJson.as[AvalancheHttpConfig].result must beRight(cfg)
+  }
+
 }

--- a/s3/src/main/scala/quasar/destination/avalanche/s3/AvalancheS3Config.scala
+++ b/s3/src/main/scala/quasar/destination/avalanche/s3/AvalancheS3Config.scala
@@ -39,7 +39,7 @@ final case class BucketConfig(
 final case class AvalancheS3Config(
     bucketConfig: BucketConfig,
     connectionUri: URI,
-    username: Option[Username],
+    username: Username,
     clusterPassword: Option[ClusterPassword],
     googleAuth: Option[GoogleAuth],
     salesforceAuth: Option[SalesforceAuth],
@@ -88,8 +88,8 @@ object AvalancheS3Config {
   }
 
   implicit def avalancheConfigCodecJson: CodecJson[AvalancheS3Config] =
-    casecodec7[BucketConfig, URI, Option[Username], Option[ClusterPassword], Option[GoogleAuth], Option[SalesforceAuth], WriteMode, AvalancheS3Config](
+    casecodec7[BucketConfig, URI, Username, Option[ClusterPassword], Option[GoogleAuth], Option[SalesforceAuth], WriteMode, AvalancheS3Config](
       AvalancheS3Config.apply,
       AvalancheS3Config.unapply)(
-      "bucketConfig", "connectionUri", "username", "clusterPassword", "googleAuth", "salesforceAuth", "writeMode")
+      "bucketConfig", "connectionUri", "username", "clusterPassword", "googleAuthId", "salesforceAuthId", "writeMode")
 }

--- a/s3/src/main/scala/quasar/destination/avalanche/s3/AvalancheS3DestinationModule.scala
+++ b/s3/src/main/scala/quasar/destination/avalanche/s3/AvalancheS3DestinationModule.scala
@@ -19,13 +19,11 @@ package quasar.destination.avalanche.s3
 import quasar.destination.avalanche._
 
 import scala.Int
-import scala.util.{Either, Right}
-
-import java.lang.String
+import scala.util.Either
 
 import argonaut._, Argonaut._
 
-import cats.data.{EitherT, NonEmptyList}
+import cats.data.EitherT
 import cats.effect.{
   Concurrent,
   ConcurrentEffect,
@@ -47,7 +45,6 @@ import quasar.blobstore.s3.{
 }
 import quasar.connector.MonadResourceErr
 import quasar.connector.destination.{Destination, PushmiPullyu}
-import quasar.lib.jdbc.TransactorConfig
 
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
@@ -59,8 +56,8 @@ object AvalancheS3DestinationModule extends AvalancheDestinationModule[Avalanche
   val destinationType: DestinationType =
     DestinationType("avalanche-s3", 1L)
 
-  def connectionConfig(config: AvalancheS3Config): ConnectionConfig = 
-    ConnectionConfig(
+  def connectionConfig(config: AvalancheS3Config): AvalancheTransactorConfig = 
+    AvalancheTransactorConfig(
       config.connectionUri,
       config.username,
       config.clusterPassword,

--- a/s3/src/main/scala/quasar/destination/avalanche/s3/AvalancheS3DestinationModule.scala
+++ b/s3/src/main/scala/quasar/destination/avalanche/s3/AvalancheS3DestinationModule.scala
@@ -59,11 +59,14 @@ object AvalancheS3DestinationModule extends AvalancheDestinationModule[Avalanche
   val destinationType: DestinationType =
     DestinationType("avalanche-s3", 1L)
 
-  def transactorConfig(config: AvalancheS3Config): Either[NonEmptyList[String], TransactorConfig] =
-    Right(AvalancheTransactorConfig(
+  def connectionConfig(config: AvalancheS3Config): ConnectionConfig = 
+    ConnectionConfig(
       config.connectionUri,
       config.username,
-      config.clusterPassword))
+      config.clusterPassword,
+      config.googleAuth,
+      config.salesforceAuth
+    )
 
   def sanitizeDestinationConfig(config: Json): Json =
     config.as[AvalancheS3Config].fold(

--- a/s3/src/test/scala/quasar/destination/avalanche/s3/AvalancheS3ConfigSpec.scala
+++ b/s3/src/test/scala/quasar/destination/avalanche/s3/AvalancheS3ConfigSpec.scala
@@ -26,6 +26,8 @@ import org.specs2.mutable.Specification
 
 import quasar.blobstore.s3._
 
+import scala.{Some, None}
+
 object AvalancheS3ConfigSpec extends Specification {
   import WriteMode._
 
@@ -51,7 +53,9 @@ object AvalancheS3ConfigSpec extends Specification {
           Region("us-east-1")),
         new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
         Username("myuser"),
-        ClusterPassword("mypassword"),
+        Some(ClusterPassword("mypassword")),
+        None,
+        None,
         Create)
 
     initialJson.as[AvalancheS3Config].result must beRight(cfg)
@@ -80,7 +84,9 @@ object AvalancheS3ConfigSpec extends Specification {
           Region("us-east-1")),
         new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
         Username("dbuser"),
-        ClusterPassword("super secret"),
+        Some(ClusterPassword("super secret")),
+        None,
+        None,
         Truncate)
 
     initialJson.as[AvalancheS3Config].result must beRight(cfg)
@@ -110,7 +116,72 @@ object AvalancheS3ConfigSpec extends Specification {
           Region("us-east-1")),
         new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
         Username("myuser"),
-        ClusterPassword("super secret"),
+        Some(ClusterPassword("super secret")),
+        None,
+        None,
+        Truncate)
+
+    initialJson.as[AvalancheS3Config].result must beRight(cfg)
+
+    cfg.asJson.as[AvalancheS3Config].result must beRight(cfg)
+  }
+
+
+  "avalanche-s3 parses and prints a valid config with google auth" >> {
+    val initialJson = Json.obj(
+      "bucketConfig" := Json.obj(
+        "bucket" := "bucket-name",
+        "credentials" := Json.obj(
+          "accessKey" := "aws-access-key",
+          "secretKey" := "aws-secret-key",
+          "region" := "us-east-1")),
+      "connectionUri" := "jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;",
+      "googleAuthId" := "00000000-0000-0000-0000-000000000000",
+      "writeMode" := "truncate")
+
+    val cfg =
+      AvalancheS3Config(
+        BucketConfig(
+          Bucket("bucket-name"),
+          AccessKey("aws-access-key"),
+          SecretKey("aws-secret-key"),
+          Region("us-east-1")),
+        new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
+        Username.DbUser,
+        None,
+        Some(GoogleAuth(UUID0)),
+        None,
+        Truncate)
+
+    initialJson.as[AvalancheS3Config].result must beRight(cfg)
+
+    cfg.asJson.as[AvalancheS3Config].result must beRight(cfg)
+  }
+
+  "avalanche-s3 parses and prints a valid config with salesforce auth" >> {
+    val initialJson = Json.obj(
+      "bucketConfig" := Json.obj(
+        "bucket" := "bucket-name",
+        "credentials" := Json.obj(
+          "accessKey" := "aws-access-key",
+          "secretKey" := "aws-secret-key",
+          "region" := "us-east-1")),
+      "connectionUri" := "jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;",
+      "salesforceAuthId" := "00000000-0000-0000-0000-000000000000",
+      "writeMode" := "truncate")
+
+    val cfg =
+      AvalancheS3Config(
+        BucketConfig(
+          Bucket("bucket-name"),
+          AccessKey("aws-access-key"),
+          SecretKey("aws-secret-key"),
+          Region("us-east-1")),
+        new URI("jdbc:ingres://cluster-id.azure.actiandatacloud.com:27839/db;encryption=on;"),
+        Username.DbUser,
+        None,
+        None,
+        Some(SalesforceAuth(UUID0)),
         Truncate)
 
     initialJson.as[AvalancheS3Config].result must beRight(cfg)


### PR DESCRIPTION
This is still pending testing in practice, hence only a draft. Otherwise pretty simple PR:

- Added new parameters to configs
  - One note about the above is that in a couple of places things were made into `Option`, which argonaut renders to `"myfield": null`, as opposed to not including them when used via `casecodec` (although it does accept json with those values missing). This yields some maybe odd looking JSON when queried e.g. via `/destinations` on sdbe. Not sure if this needs addressing with a custom codec or not.
- The google/salesforce user info endpoints are embedded right into the code. Not sure if this is the right way to do it.