### PR TITLE
Increased char column bounds to 32000 bytes max

### DIFF
--- a/core/src/main/scala/quasar/destination/avalanche/AvalancheDestination.scala
+++ b/core/src/main/scala/quasar/destination/avalanche/AvalancheDestination.scala
@@ -147,7 +147,7 @@ abstract class AvalancheDestination[F[_]: MonadResourceErr: Sync: Timer](
 
   private def withCharLength(mkType: Int => Type): Either[Type, Constructor[Type]] =
     Right(Constructor.Unary(
-      Labeled("size", Formal.integer(Some(Ior.both(1, 16000)), Some(stepOne), Some(1024))),
+      Labeled("size", Formal.integer(Some(Ior.both(1, 32000)), Some(stepOne), Some(1024))),
       mkType))
 
   private def withSeconds(mkType: Int => Type): Either[Type, Constructor[Type]] =


### PR DESCRIPTION
[ch13292]

Increased the max size of (var)char columns to 32000 bytes, which is the max as per [actian docs](https://docs.actian.com/avalanche/index.html#page/SQLLanguage/SQL_Data_Types.htm#ww415213)

Not sure if this should be a revision or a feature? 
